### PR TITLE
Fix `max` method not found issue

### DIFF
--- a/src/aspect/utils.lua
+++ b/src/aspect/utils.lua
@@ -16,6 +16,7 @@ local nkeys = table.nkeys -- luajit 2.1
 local isarray = table.isarray -- luajit 2.1
 local pcall = pcall
 local select = select
+local max = math.max
 
 local utils = {
     starts_with = string.startswith


### PR DESCRIPTION
Make `math.max` method locally
